### PR TITLE
Prevent link error when json.h is included into several files

### DIFF
--- a/json.c
+++ b/json.c
@@ -36,6 +36,8 @@
    #endif
 #endif
 
+const int json_relaxed_commas = 1;
+
 #ifdef __cplusplus
    const struct _json_value json_value_none; /* zero-d by ctor */
 #else

--- a/json.h
+++ b/json.h
@@ -51,7 +51,7 @@ typedef struct
 
 } json_settings;
 
-const int json_relaxed_commas = 1;
+extern const int json_relaxed_commas;
 
 typedef enum
 {


### PR DESCRIPTION
Declare `json_relaxed_commas` as extern within json.h to avoid any
duplicate symbol link error.
