### PR TITLE
Fix MSVC warnings with 64bit json_int_t

### DIFF
--- a/json.c
+++ b/json.c
@@ -617,7 +617,7 @@ json_value * json_parse_ex (json_settings * settings, const json_char * json, ch
                   }
 
                   top->type = json_double;
-                  top->u.dbl = top->u.integer;
+                  top->u.dbl = (double) top->u.integer;
 
                   num_digits = 0;
                   continue;
@@ -642,7 +642,7 @@ json_value * json_parse_ex (json_settings * settings, const json_char * json, ch
                      if (top->type == json_integer)
                      {
                         top->type = json_double;
-                        top->u.dbl = top->u.integer;
+                        top->u.dbl = (double) top->u.integer;
                      }
 
                      num_digits = 0;

--- a/json.h
+++ b/json.h
@@ -171,7 +171,7 @@ typedef struct _json_value
             };
          }
 
-         inline operator long () const
+         inline operator json_int_t () const
          {  
             switch (type)
             {
@@ -179,7 +179,7 @@ typedef struct _json_value
                   return u.integer;
 
                case json_double:
-                  return (long) u.dbl;
+                  return (json_int_t) u.dbl;
 
                default:
                   return 0;
@@ -199,7 +199,7 @@ typedef struct _json_value
             switch (type)
             {
                case json_integer:
-                  return u.integer;
+                  return (double) u.integer;
 
                case json_double:
                   return u.dbl;


### PR DESCRIPTION
Some lines of code were making implicit narrowing casts. I put an explicit cast in most cases, but I changed `operator long ()` to `operator json_int_t()` (which I hope is acceptable). I don't know if there should be separate `long` and `json_int_t` operators.
