### PR TITLE
Fix order of calloc call

### DIFF
--- a/json.c
+++ b/json.c
@@ -78,7 +78,7 @@ typedef struct
 
 static void * default_alloc (size_t size, int zero, void * user_data)
 {
-   return zero ? calloc (size, 1) : malloc (size);
+   return zero ? calloc (1, size) : malloc (size);
 }
 
 static void default_free (void * ptr, void * user_data)


### PR DESCRIPTION
Although the original version works as expected, the argument order should be changed to calloc's signature:
void\* calloc (size_t num, size_t size);
http://www.cplusplus.com/reference/cstdlib/calloc/
