### PR TITLE
Expose maximum size for error buffer in header

### DIFF
--- a/json.c
+++ b/json.c
@@ -209,7 +209,7 @@ json_value * json_parse_ex (json_settings * settings,
                             size_t length,
                             char * error_buf)
 {
-   json_char error [128];
+   json_char error [json_error_max];
    unsigned int cur_line;
    const json_char * cur_line_begin, * i, * end;
    json_value * top, * root, * alloc = 0;

--- a/json.h
+++ b/json.h
@@ -244,6 +244,7 @@ typedef struct _json_value
 json_value * json_parse (const json_char * json,
                          size_t length);
 
+#define json_error_max 128
 json_value * json_parse_ex (json_settings * settings,
                             const json_char * json,
                             size_t length,


### PR DESCRIPTION
I felt uncomfortable just having a magic number in my code, having to remember to update it whenever the value changes in `json.c`, so I added this definition in `json.h`. Let me know if it needs to be in all caps (json_relaxed_commas was in all lowercase) or if it needs to be moved to a different line in the header file (I just placed it above `json_parse_ex` since that's the function that takes the error buffer parameter)[.](https://github.com/udp/json-parser/commit/09896ab92be35a5e6039cb1d0715fcc0fb3d0fd1)
