### PR TITLE
Slightly better support for null characters in strings

### DIFF
--- a/json.h
+++ b/json.h
@@ -49,6 +49,7 @@
 #ifdef __cplusplus
 
    #include <string.h>
+   #include <string>
 
    extern "C"
    {
@@ -193,6 +194,18 @@ typedef struct _json_value
             {
                case json_string:
                   return u.string.ptr;
+
+               default:
+                  return "";
+            };
+         }
+
+         inline operator std::string () const
+         {  
+            switch (type)
+            {
+               case json_string:
+                  return std::string(u.string.ptr, u.string.length);
 
                default:
                   return "";


### PR DESCRIPTION
The JSON format allows null characters in strings (both names and values) in the form of `\u0000` anywhere in a string. Currently json-parser has a length field associated with `json_string`, but no such field associated with each name in `json_object`. I also haven't checked how json-parser handles the null character in various cases.

This PR is just a slight convenience - it adds a C++ operator to convert to `std::string` which uses the length field instead of stopping at the first null character in the string. However more work will still need to be done to fully support null characters in strings. If you want I can open a separate issue for this.
