### PR TITLE
Add LDFLAGS support and missing lm option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,7 +29,7 @@ libjsonparser.a: $(OBJS)
 	$(AR) rcs libjsonparser.a json.o
 
 libjsonparser.so: $(OBJS)
-	$(CC) -shared -Wl,-soname,$(SO_NAME) -o libjsonparser.so $^
+	$(CC) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o libjsonparser.so $^ -lm
 
 libjsonparser.dylib: $(OBJS)
 	$(CC) -dynamiclib json.o -o libjsonparser.dylib


### PR DESCRIPTION
While libm can be linked on generating final executable, it's still
preferred to link it against the library itself to better represent the
dependency hierarchy.