### PR TITLE
Enable C++ iterators in MSVC (and C++98)

### DIFF
--- a/json.h
+++ b/json.h
@@ -123,11 +123,11 @@ typedef struct _json_value
 
          json_object_entry * values;
 
-         #if defined(__cplusplus) && __cplusplus >= 201103L
-         decltype(values) begin () const
+         #if defined(__cplusplus)
+         json_object_entry * begin () const
          {  return values;
          }
-         decltype(values) end () const
+         json_object_entry * end () const
          {  return values + length;
          }
          #endif
@@ -139,11 +139,11 @@ typedef struct _json_value
          unsigned int length;
          struct _json_value ** values;
 
-         #if defined(__cplusplus) && __cplusplus >= 201103L
-         decltype(values) begin () const
+         #if defined(__cplusplus)
+         _json_value ** begin () const
          {  return values;
          }
-         decltype(values) end () const
+         _json_value ** end () const
          {  return values + length;
          }
          #endif


### PR DESCRIPTION
Iterators (begin() and end() methods) were implemented using `decltype` for the return types, which seems to be possible only since C++11. Therefore, the code used the value of the `__cplusplus` pre-processor symbol to check for C++11. This did not work as expected in MSVC, however, because even the recent Visual Studio 2017 defines the symbol as 199711L, effectively disabling iterators.

Replaced the `decltype` usages with the respective type names; and no longer check the value of `__cplusplus`. Iterators are now available in MSVC and, as a side-effect, also in C++98.

Tested with Visual Studio 2017 (version 15.6.3) and "g++ -std=c++98".