### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: c
+arch:
+ - amd64
+ - ppc64le
+ 
 script: "cc -ansi -pedantic -Wall -Werror -c json.c"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ arch:
  - amd64
  - ppc64le
  
+ 
 script: "cc -ansi -pedantic -Wall -Werror -c json.c"
 branches:
   only:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/json-parser/builds/198726392

Please have a look.

Regards,
Manish Kumar