### PR TITLE
Remove dependency to the math library.

### DIFF
--- a/configure
+++ b/configure
@@ -634,6 +634,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_math
 enable_debug
 enable_track_source
 '
@@ -1270,6 +1271,14 @@ Optional Features:
   --enable-track-source   Lets the json-parser user retrieve the source
                           line/column number of a parsed json_value.
                           [default=disabled]
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --without-math          Avoid using the math library. Use internal math
+                          functionality instead. This can reduce the code size
+                          if the math library is not used elsewere.
+                          [default=no], which means "Use the math library".
 
 Some influential environment variables:
   CC          C compiler command
@@ -2630,6 +2639,21 @@ esac
   fi
 else
   AR="$ac_cv_prog_AR"
+fi
+
+
+
+# Check whether --with-math was given.
+if test "${with_math+set}" = set; then :
+  withval=$with_math; with_math="$withval"
+else
+  with_math=yes
+
+fi
+
+
+if test "x$with_math" = xno; then
+	CFLAGS="$CFLAGS -DJSON_INTERNAL_MATH"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,20 @@ VERSION_MAJOR="1.1"
 AC_PROG_CC
 AC_CHECK_TOOL(AR, ar, :)
 
+AC_ARG_WITH([math],
+	[AS_HELP_STRING([--without-math],
+		[Avoid using the math library. Use internal math functionality instead.
+		This can reduce the code size if the math library is not used elsewere. 
+		@<:@default=no@:>@, which means "Use the math library".])],
+	[with_math="$withval"],
+	[with_math=yes]
+)
+
+if test "x$with_math" = xno; then
+	CFLAGS="$CFLAGS -DJSON_INTERNAL_MATH"
+fi 
+
+
 AC_ARG_ENABLE([debug],
 	[AS_HELP_STRING([--enable-debug],
 		 [Build a debug version of json-parser @<:@default=disabled@:>@])],

--- a/json.c
+++ b/json.c
@@ -40,7 +40,6 @@
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#include <math.h>
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
    /* C99 might give us uintptr_t and UINTPTR_MAX but they also might not be provided */
@@ -102,6 +101,31 @@ typedef char json_size_t_static_assert[(JSON_SIZE_MAX >= UINT_MAX) ? 1 : -1]; /*
 typedef unsigned int json_uchar;
 
 const struct _json_value json_value_none;
+
+static double json_pow10 (int exp)
+{
+  double base = 10.0;
+  double result = 1.0;
+  int neg = exp < 0;
+
+  exp = !neg ? exp : -exp;
+  exp = exp <= 308 ? exp : 309; /* double max exp = 308, allows the "infinite" number */
+
+  while (1)
+  {
+    if (exp & 1)
+      result *= base;
+
+    exp >>= 1;
+
+    if (!exp)
+      break;
+
+    base *= base;
+  }
+
+  return !neg ? result : 1 / result;
+}
 
 static unsigned char hex_value (json_char c)
 {
@@ -941,7 +965,7 @@ json_value * json_parse_ex (json_settings * settings,
                         goto e_failed;
                      }
 
-                     top->u.dbl += num_fraction / pow (10.0, num_digits);
+                     top->u.dbl += num_fraction / json_pow10 (num_digits);
                   }
 
                   if (b == 'e' || b == 'E')
@@ -968,7 +992,7 @@ json_value * json_parse_ex (json_settings * settings,
                      goto e_failed;
                   }
 
-                  top->u.dbl *= pow (10.0, (flags & flag_num_e_negative ? - num_e : num_e));
+                  top->u.dbl *= json_pow10 ((flags & flag_num_e_negative ? - num_e : num_e));
                }
 
                if (flags & flag_num_negative)

--- a/json.c
+++ b/json.c
@@ -64,6 +64,13 @@
 #define JSON_INT_MAX (json_int_t)(((unsigned json_int_t)(-1)) / (unsigned json_int_t)2);
 #endif
 
+#ifdef JSON_INTERNAL_MATH
+   #define json_pow(a) json_pow10((a))
+#else
+   #include <math.h>
+   #define json_pow(a) pow(10.0,(a))
+#endif
+
 #ifndef JSON_UINTPTR_T
    #ifdef UINTPTR_MAX
       /* C99 */
@@ -102,6 +109,7 @@ typedef unsigned int json_uchar;
 
 const struct _json_value json_value_none;
 
+#ifdef JSON_INTERNAL_MATH
 static double json_pow10 (int exp)
 {
   double base = 10.0;
@@ -126,6 +134,7 @@ static double json_pow10 (int exp)
 
   return !neg ? result : 1 / result;
 }
+#endif
 
 static unsigned char hex_value (json_char c)
 {
@@ -965,7 +974,7 @@ json_value * json_parse_ex (json_settings * settings,
                         goto e_failed;
                      }
 
-                     top->u.dbl += num_fraction / json_pow10 (num_digits);
+                     top->u.dbl += num_fraction / json_pow (num_digits);
                   }
 
                   if (b == 'e' || b == 'E')
@@ -992,7 +1001,7 @@ json_value * json_parse_ex (json_settings * settings,
                      goto e_failed;
                   }
 
-                  top->u.dbl *= json_pow10 ((flags & flag_num_e_negative ? - num_e : num_e));
+                  top->u.dbl *= json_pow ((flags & flag_num_e_negative ? - num_e : num_e));
                }
 
                if (flags & flag_num_negative)


### PR DESCRIPTION
Introducing json_pow10(), a fast power of 10 calculator, which suits JSON perfectly. (Named json_pow10 to avoid conflict with gcc builtin functions.)
