### PR TITLE
configure complains about ignored datarootdir variable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,6 +4,7 @@ prefix = @prefix@
 
 includedir = $(DESTDIR)@includedir@
 libdir = $(DESTDIR)@libdir@
+datarootdir = @datarootdir@
 datadir = $(DESTDIR)@datadir@
 
 AR = @AR@


### PR DESCRIPTION
When running the `configure` script, you are warned 
```
config.status: WARNING:  'Makefile.in' seems to ignore the --datarootdir setting
```
because the option value is not passed on to the Makefile generation.