### PR TITLE
Fix header files

### DIFF
--- a/json.c
+++ b/json.c
@@ -39,6 +39,7 @@
 const struct _json_value json_value_none;
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <math.h>

--- a/json.h
+++ b/json.h
@@ -37,14 +37,14 @@
 
 #ifndef json_int_t
    #ifndef _MSC_VER
-      #include <inttypes.h>
+      #include <stdint.h>
       #define json_int_t int64_t
    #else
       #define json_int_t __int64
    #endif
 #endif
 
-#include <stdlib.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
**json.h**: `<inttypes.h>` → `<stdint.h>`
`int64_t` is defined in [`<stdint.h>`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdint.h.html#tag_13_48), no need for the full [`<inttypes.h>`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/inttypes.h.html#tag_13_20)

**json.h**: `<stdlib.h>` → `<stddef.h>`
[`<stddef.h>`](https://en.cppreference.com/w/c/types) is enough to define `size_t`

**json.c**: `<stdlib.h>`
Now that `<stdlib.h>` has been removed from json.h, add it to json.c for malloc()/calloc() and free()