### PR TITLE
Add $(CFLAGS) to compiler options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,10 +31,10 @@ libjsonparser.a: $(OBJS)
 	$(AR) rcs libjsonparser.a $^
 
 libjsonparser.so: $(OBJS)
-	$(CC) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o libjsonparser.so $^ -lm
+	$(CC) $(CFLAGS) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o libjsonparser.so $^ -lm
 
 libjsonparser.dylib: $(OBJS)
-	$(CC) -dynamiclib $^ -o libjsonparser.dylib
+	$(CC) $(CFLAGS) -dynamiclib $^ -o libjsonparser.dylib
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $^


### PR DESCRIPTION
Avoid the following linking error on Ubuntu 20.04:
```
/usr/bin/ld: /tmp/ccPCOj2I.o: relocation R_X86_64_PC32 against symbole `json_value_free_ex' can not be used when making a shared object; recompilez avec -fPIC
```