### PR TITLE
Copyright dates and web site updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-  Copyright (C) 2012, 2013 James McLaughlin et al.  All rights reserved.
+  Copyright (C) 2012-2021 the json-parser authors  All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Very low footprint JSON parser written in portable ANSI C.
 
 [![Build Status](https://github.com/json-parser/json-parser/actions/workflows/main.yml/badge.svg)](https://github.com/json-parser/json-parser/actions)
 
-_Want to serialize?  Check out [json-builder](https://github.com/udp/json-builder)!_
+_Want to serialize?  Check out [json-builder](https://github.com/json-parser/json-builder)!_
 
 Installing
 ----------

--- a/bindings/python/wrap_json.c
+++ b/bindings/python/wrap_json.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Mathias Kaerlev.  All rights reserved.
+ * Copyright (C) 2012-2021 the json-parser authors  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/examples/test_json.c
+++ b/examples/test_json.c
@@ -1,7 +1,7 @@
 /* vim: set et ts=4
  *
- * Copyright (C) 2015 Mirko Pasqualetti  All rights reserved.
- * https://github.com/udp/json-parser
+ * Copyright (C) 2015-2021 the json-parser authors  All rights reserved.
+ * https://github.com/json-parser/json-parser
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/json.c
+++ b/json.c
@@ -1,7 +1,7 @@
 /* vim: set et ts=3 sw=3 sts=3 ft=c:
  *
- * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
- * https://github.com/udp/json-parser
+ * Copyright (C) 2012-2021 the json-parser authors  All rights reserved.
+ * https://github.com/json-parser/json-parser
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/json.h
+++ b/json.h
@@ -1,8 +1,8 @@
 
 /* vim: set et ts=3 sw=3 sts=3 ft=c:
  *
- * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
- * https://github.com/udp/json-parser
+ * Copyright (C) 2012-2021 the json-parser authors  All rights reserved.
+ * https://github.com/json-parser/json-parser
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
Perhaps it's time we change:
```
 * Copyright (C) 2012, 2013, 2014, 2016, 2018, 2019, 2021 James McLaughlin et al.  All rights reserved.
```
to:
```
 * Copyright (C) 2012-2021 James McLaughlin et al.  All rights reserved.
```
