### PR TITLE
Use object files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,10 +31,10 @@ libjsonparser.a: $(OBJS)
 	$(AR) rcs libjsonparser.a $^
 
 libjsonparser.so: $(OBJS)
-	$(CC) $(CFLAGS) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o libjsonparser.so $^ -lm
+	$(CC) -shared -Wl,-soname,$(SO_NAME) $(LDFLAGS) -o libjsonparser.so $^ -lm
 
 libjsonparser.dylib: $(OBJS)
-	$(CC) $(CFLAGS) -dynamiclib $^ -o libjsonparser.dylib
+	$(CC) -dynamiclib $^ -o libjsonparser.dylib
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $^

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,7 +13,7 @@ CC = @CC@
 CFLAGS = @CFLAGS@
 LDFLAGS = @LDFLAGS@
 SRCS = $(wildcard $(srcdir)/*.c)
-OBJS = $(SRCS: $(srcdir)/%.c=%.o)
+OBJS = $(SRCS:$(srcdir)/%.c=%.o)
 
 ifeq ($(shell uname),Darwin)
 	SO_EXT := dylib
@@ -36,7 +36,7 @@ libjsonparser.so: $(OBJS)
 libjsonparser.dylib: $(OBJS)
 	$(CC) -dynamiclib $^ -o libjsonparser.dylib
 
-%.o: %.c
+%.o: $(srcdir)/%.c
 	$(CC) $(CFLAGS) -c $^
 
 clean:


### PR DESCRIPTION
Object files are not used in the linking process.  The source files are used directly, thereby ignoring the CFLAGS variable.

This pull request reverses pull request #114 and implements what is given in [this comment](https://github.com/json-parser/json-parser/pull/114#issuecomment-902580631). 