### PR TITLE
Fix Coverity Scan defect

### DIFF
--- a/json.c
+++ b/json.c
@@ -774,10 +774,12 @@ json_value * json_parse_ex (json_settings * settings,
                      }
 
                      if (would_overflow(top->u.integer, b))
-                     {  -- num_digits;
+                     {
+                        json_int_t integer = top->u.integer;
+                        -- num_digits;
                         -- state.ptr;
                         top->type = json_double;
-                        top->u.dbl = (double)top->u.integer;
+                        top->u.dbl = (double)integer;
                         continue;
                      }
 


### PR DESCRIPTION
CID 308347: Assignment of overlapping memory (OVERLAPPING_COPY)
**overlapping_assignment:** Assigning `top->u.integer` to `top->u.dbl`, which have overlapping memory locations and different types.

See following discussion:
[Is assigning to a union member from a different member in the same union defined by the C standard?](https://stackoverflow.com/questions/65077630/is-assigning-to-a-union-member-from-a-different-member-in-the-same-union-defined)