### PR TITLE
num_digits: double → int

### DIFF
--- a/json.c
+++ b/json.c
@@ -243,8 +243,8 @@ json_value * json_parse_ex (json_settings * settings,
    json_value * top, * root, * alloc = 0;
    json_state state = { 0 };
    long flags = 0;
-   double num_digits = 0, num_e = 0;
-   double num_fraction = 0;
+   int num_digits = 0;
+   double num_e = 0, num_fraction = 0;
 
    /* Skip UTF-8 BOM
     */


### PR DESCRIPTION
It looks like a bad idea to apply operators `++` and `--` to a `double`, or to compare a `double` to integer values.