### PR TITLE
Executable file should be executable

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 # See bindings/python for the python jsonparser module
 


### PR DESCRIPTION
File `test.py` is executable in Git, yet does not start with "**`#!`**".

The alternative would be to:
```sh
git update-index --chmod=-x tests/test.py
```