### PR TITLE
Fix strict-aliasing warning

### DIFF
--- a/json.c
+++ b/json.c
@@ -176,7 +176,7 @@ static int new_value (json_state * state,
                return 0;
             }
 
-            value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;
+            value->_reserved.object_mem = (void *) (((char *) value->u.object.values) + values_size);
 
             value->u.object.length = 0;
             break;

--- a/json.c
+++ b/json.c
@@ -432,8 +432,10 @@ json_value * json_parse_ex (json_settings * settings,
 
                   case json_object:
 
-                     if (state.first_pass)
-                        (*(json_char **) &top->u.object.values) += string_length + 1;
+                     if (state.first_pass) {
+                        json_char **chars = (json_char **) &top->u.object.values;
+                        chars[0] += string_length + 1;
+                     }
                      else
                      {
                         top->u.object.values [top->u.object.length].name


### PR DESCRIPTION
A couple of lines trigger `strict-aliasing` warnings on `gcc` (Ubuntu)
```
error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
```
Output of `gcc --version`
```
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
This PR addresses those two warnings

Commit d7b67db02aaa17fcc9bfbc8b60f41c3b677bd5a8 also simplifies the pointer notation by removing a reference and a dereference that seem to cancel each other out. Let's say that `value->u.object.values` is a pointer in memory location _A_ and points to location _B_. Then
| expression | type | pointer location | pointed location |
|---|---|---|---|
| `value->u.object.values` | `json_object_entry *` | _A_ | _B_ |
| `&value->u.object.values` | `json_object_entry **` |  | _A_ |
| `(char **) &value->u.object.values` | `char **` |  | _A_ |
| `*(char **) &value->u.object.values` | `char *` |  | _B_ |

The last expression can be simplified in
```(char *) value->u.object.values```