### PR TITLE
Install pkgconfig file to $(libdir)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,9 +43,9 @@ clean:
 	rm -f libjsonparser.$(SO_EXT) libjsonparser.a json.o
 
 install-shared: libjsonparser.$(SO_EXT)
-	@echo Installing pkgconfig module: $(datadir)/pkgconfig/json-parser.pc
-	@install -d $(datadir)/pkgconfig/ || true
-	@install -m 0644 json-parser.pc $(datadir)/pkgconfig/json-parser.pc
+	@echo Installing pkgconfig module: $(libdir)/pkgconfig/json-parser.pc
+	@install -d $(libdir)/pkgconfig/ || true
+	@install -m 0644 json-parser.pc $(libdir)/pkgconfig/json-parser.pc
 	@echo Installing shared library: $(libdir)/libjsonparser.$(SO_EXT)
 	@install -d $(libdir) || true
 	@install -m 0755 libjsonparser.$(SO_EXT) $(libdir)/$(REAL_NAME)


### PR DESCRIPTION
Pkgconfig file needs to be installed in `$(libdir)` rather than `$(datadir)`, otherwise it is not possible to support multilib systems
properly, e.g. 32 and 64 bits library on one system, where location must differ `/usr/lib/pkgconfig` for 32bit and `/usr/lib64/pkgconfig` for 64bit, for example.