### PR TITLE
fix(python): Add Python 3 compatibility macros for PyInt functions 

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,7 +8,8 @@ ext_modules.append(Extension('jsonparser',
 
 
 setup(
-    name = 'json-parser python wrapper',
+    name = 'json-parser-python-wrapper',
+    version = '1.1.0',
     cmdclass = {'build_ext': build_ext},
     ext_modules = ext_modules
 )

--- a/bindings/python/wrap_json.c
+++ b/bindings/python/wrap_json.c
@@ -27,6 +27,18 @@
 
 #include "../../json.c"
 
+#include <Python.h>
+
+#if PY_MAJOR_VERSION >= 3
+  /* Define PyInt_* only for Python 3, where they no longer exist */
+  #ifndef PyInt_FromLong
+    #define PyInt_FromLong PyLong_FromLong
+  #endif
+  #ifndef PyInt_AsLong
+    #define PyInt_AsLong  PyLong_AsLong
+  #endif
+#endif
+
 PyObject * json_exception = PyErr_NewException("jsonparser.JSONException",
     NULL, NULL);
 


### PR DESCRIPTION
- [Add Python 3 compatibility macros for PyInt functions](https://github.com/json-parser/json-parser/commit/73cbc90851d0deb31cb3508c7eb646debb05c70d)
- [Update package name and add version in setup.py](https://github.com/json-parser/json-parser/commit/f4511e38a16a4cad94770d19eaab472f4ade5bc4)

See also: https://github.com/gentoo/gentoo/pull/41956
Bug: https://bugs.gentoo.org/955499
Bug: https://bugs.gentoo.org/954840