### PR TITLE
Save strings internally as WTF-8

### DIFF
--- a/json.c
+++ b/json.c
@@ -339,24 +339,50 @@ json_value * json_parse_ex (json_settings * settings,
                     uc_b2 = (uc_b3 << 4) | uc_b4;
                     uchar = (uc_b1 << 8) | uc_b2;
 
-                    if ((uchar & 0xF800) == 0xD800) {
-                        json_uchar uchar2;
+                    if ((uchar & 0xF800) == 0xD800)
+                    {
+                       json_uchar uchar2;
+                       const char *saved_ptr = state.ptr;
 
-                        if (end - state.ptr <= 6 || (*++ state.ptr) != '\\' || (*++ state.ptr) != 'u' ||
-                            (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
-                            (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
-                            (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
-                            (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
-                        {
-                            sprintf (error, "%u:%u: Invalid character value `%c`", line_and_col, b);
-                            goto e_failed;
-                        }
+                       /* Only try pairing if this is a HIGH surrogate */
+                       if ((uchar & 0xFC00) == 0xD800)
+                       {
+                          /* Try to read second half */
+                          if ((end - state.ptr > 6) &&
+                             (*++state.ptr == '\\') &&
+                             (*++state.ptr == 'u') &&
+                             (uc_b1 = hex_value(*++state.ptr)) != 0xFF &&
+                             (uc_b2 = hex_value(*++state.ptr)) != 0xFF &&
+                             (uc_b3 = hex_value(*++state.ptr)) != 0xFF &&
+                             (uc_b4 = hex_value(*++state.ptr)) != 0xFF)
+                          {
+                             uc_b1 = (uc_b1 << 4) | uc_b2;
+                             uc_b2 = (uc_b3 << 4) | uc_b4;
+                             uchar2 = (uc_b1 << 8) | uc_b2;
 
-                        uc_b1 = (uc_b1 << 4) | uc_b2;
-                        uc_b2 = (uc_b3 << 4) | uc_b4;
-                        uchar2 = (uc_b1 << 8) | uc_b2;
+                             /* Valid surrogate pair? */
+                             if ((uchar2 & 0xFC00) == 0xDC00)
+                             {
+                                uchar = 0x010000 +
+                                   (((uchar  - 0xD800) << 10) |
+                                     (uchar2 - 0xDC00));
+                             }
+                             else
+                             {
+                                /* Not a low surrogate → rollback and keep uchar as-is */
+                                state.ptr = saved_ptr;
+                             }
+                          }
+                          else
+                          {
+                             /* Incomplete second part → rollback and keep uchar as-is */
+                             state.ptr = saved_ptr;
+                          }
+                       }
 
-                        uchar = 0x010000 | ((uchar & 0x3FF) << 10) | (uchar2 & 0x3FF);
+                       /* If it's a low surrogate or unpaired high surrogate, we just
+                        * let it continue normally, and it'll be UTF-8 encoded below
+                        */
                     }
 
                     if (sizeof (json_char) >= sizeof (json_uchar) || (uchar <= 0x7F))

--- a/tests/test.c
+++ b/tests/test.c
@@ -224,9 +224,9 @@ int main(void)
    JSON_COMPARE_STRING(0, "\\r\\n", "\r\n");
    JSON_COMPARE_STRING(2, "abc \0 123", "abc \0 123"); /* TODO: should this really be disallowed? */
    JSON_COMPARE_STRING(0, "abc \\u0000 123", "abc \0 123");
-   JSON_COMPARE_STRING(1, "\\ud841\\udf31", "𠜱"); /* TODO: this should actually succeed after PR #58 is merged */
+   JSON_COMPARE_STRING(0, "\\ud841\\udf31", "𠜱");
 
-   if(0 != json_verify(      "valid-%04u.json", 13, 0, 0)){ exit_code = EXIT_FAILURE; }
+   if(0 != json_verify(      "valid-%04u.json", 14, 0, 0)){ exit_code = EXIT_FAILURE; }
    if(0 != json_verify(    "invalid-%04u.json", 10, 0, 1)){ exit_code = EXIT_FAILURE; }
    if(0 != json_verify(  "ext-valid-%04u.json",  3, 1, 0)){ exit_code = EXIT_FAILURE; }
    if(0 != json_verify("ext-invalid-%04u.json",  2, 1, 1)){ exit_code = EXIT_FAILURE; }

--- a/tests/valid-0014.json
+++ b/tests/valid-0014.json
@@ -1,0 +1,14 @@
+{
+  "valid surrogate pair (😀 U+1F600)": "\uD83D\uDE00",
+  "lone high surrogate": "\uD800",
+  "lone low surrogate": "\uDC00",
+  "high surrogate not followed by low surrogate": "\uD834\u0061",
+  "low surrogate not preceded by high surrogate": "\u0061\uDD1E",
+  "reversed surrogate order (low then high)": "\uDC00\uD800",
+  "two high surrogates in a row": "\uD800\uD801",
+  "two low surrogates in a row": "\uDC00\uDC01",
+  "surrogate pair split by space": "\uD83D\u0020\uDE00",
+  "surrogate halves separated by text": "\uD83Dtest\uDE00",
+  "high surrogate followed by another escape": "\uD83D\u000A",
+  "high surrogate at end of string": "ABC\uD800"
+}


### PR DESCRIPTION
RFC 8259 doesn't force strings to be valid unicode stings. In real it allows to contain any \uxxxx values. It's possible to keep any binary data in JSON strings. This commit removes limitation for strings to be valid UTF-8 strings.

WTF-8 (Wobbly Transformation Format − 8-bit) is asuperset of UTF-8 that encodes surrogate code points if they are not in a pair. It represents, in a way compatible with UTF-8, text from systems such as JavaScript and Windows that use UTF-16 internally but don’t enforce the well-formedness invariant that surrogates must be paired.

WTF-8 strings are not compatible with current tests. Tests use some python code which works only with valid UTF-8 strings. Need to upgrade tests system or replace it with something another that has full JSON support.