### PR TITLE
Guard array/object allocation size against integer overflow

### DIFF
--- a/json.c
+++ b/json.c
@@ -150,6 +150,25 @@ static int new_value (json_state * state,
             if (value->u.array.length == 0)
                break;
 
+            /*
+               value->u.array.length is bounded by UINT_MAX - 8 (see the
+               overflow check where it's incremented), but on platforms
+               where size_t is only 32 bits wide that's still enough to
+               wrap this multiplication around and hand json_alloc a
+               size far too small for the number of elements we're about
+               to write into it. Copying into a size_t first (rather than
+               comparing value->u.array.length, an unsigned int, directly
+               against a size_t-sized bound) keeps this a real runtime
+               check on every platform instead of one some compilers can
+               prove ahead of time never fires on 64-bit builds.
+            */
+            {
+               size_t array_length = value->u.array.length;
+
+               if (array_length > ((size_t) -1) / sizeof (json_value *))
+                  return 0;
+            }
+
             if (! (value->u.array.values = (json_value **) json_alloc
                (state, value->u.array.length * sizeof (json_value *), 0)) )
             {
@@ -164,6 +183,14 @@ static int new_value (json_state * state,
             if (value->u.object.length == 0)
                break;
 
+            /* same reasoning as the array case above */
+            {
+               size_t object_length = value->u.object.length;
+
+               if (object_length > ((size_t) -1) / sizeof (*value->u.object.values))
+                  return 0;
+            }
+
             values_size = sizeof (*value->u.object.values) * value->u.object.length;
 
             /*
@@ -171,6 +198,9 @@ static int new_value (json_state * state,
                The size represents the storage space needed for object key names.
                Now during the second pass, it's replaced with an actual allocation.
             */
+            if (values_size > ((size_t) -1) - (size_t) value->u.object.values)
+               return 0;
+
             if (! (value->u.object.values = (json_object_entry *) json_alloc
                #ifdef UINTPTR_MAX
                   (state, values_size + ((uintptr_t) value->u.object.values), 0)) )

--- a/tests/test_overflow_guard.c
+++ b/tests/test_overflow_guard.c
@@ -1,0 +1,101 @@
+/*
+   The overflow this guards against (see new_value() in json.c, the
+   json_array and json_object cases) only wraps around on a platform
+   where size_t is 32 bits wide, and only once an array or object has
+   grown past roughly a billion entries. Reproducing that for real would
+   need a 32-bit build and a multi-gigabyte input just to get past the
+   first pass, which isn't practical to run here or in CI.
+
+   Instead, this simulates an ILP32-style platform directly: uint32_t
+   standing in for both `unsigned int` (the type of json_value's length
+   fields) and `size_t` (the type of the allocation size), which is
+   exactly the situation the original report described. It checks that
+   the same guard formula used in json.c both (a) lets ordinary, safe
+   lengths through and (b) catches the boundary value that would
+   otherwise wrap the multiplication and hand an undersized allocation
+   to code that's about to write well past the end of it.
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#define ELEMENT_SIZE 16u /* stand-in for sizeof (json_value *) on a 32-bit build */
+
+/* Same shape as the check added to new_value() in json.c, just typed for
+   the simulated 32-bit platform instead of the host's real size_t. */
+static int would_overflow (uint32_t length, uint32_t element_size)
+{
+   return length > ((uint32_t) -1) / element_size;
+}
+
+int main (void)
+{
+   int failures = 0;
+
+   /* A modest, entirely realistic length must never be rejected. */
+   if (would_overflow (1000, ELEMENT_SIZE))
+   {
+      fprintf (stderr, "FAIL: a small, safe length was rejected\n");
+      failures++;
+   }
+
+   /* The largest length new_value()'s own increment guard ever allows
+      through (UINT_MAX - 8) is exactly the case the original report was
+      about: on a 32-bit build this is large enough that length * element_size
+      wraps around unless it's caught first. */
+   {
+      uint32_t max_allowed_length = ((uint32_t) -1) - 8;
+
+      if (! would_overflow (max_allowed_length, ELEMENT_SIZE))
+      {
+         fprintf (stderr, "FAIL: a length known to overflow the multiplication was accepted\n");
+         failures++;
+      }
+
+      /* Demonstrate what the unguarded code actually did: the raw
+         multiplication wraps to something far smaller than the real size
+         needed, which is the undersized allocation at the root of the bug. */
+      {
+         uint32_t wrapped = max_allowed_length * ELEMENT_SIZE;
+         uint64_t real_size = (uint64_t) max_allowed_length * ELEMENT_SIZE;
+
+         if (wrapped == (uint32_t) real_size && real_size > (uint32_t) -1)
+         {
+            printf ("confirmed: unguarded 32-bit multiplication wraps to %u bytes "
+                    "instead of the %llu bytes actually needed\n",
+                    wrapped, (unsigned long long) real_size);
+         }
+         else
+         {
+            fprintf (stderr, "FAIL: expected the raw multiplication to wrap on a 32-bit platform\n");
+            failures++;
+         }
+      }
+   }
+
+   /* The exact boundary: one element fewer should just barely fit. */
+   {
+      uint32_t boundary_length = ((uint32_t) -1) / ELEMENT_SIZE;
+
+      if (would_overflow (boundary_length, ELEMENT_SIZE))
+      {
+         fprintf (stderr, "FAIL: the exact boundary length was rejected\n");
+         failures++;
+      }
+
+      if (! would_overflow (boundary_length + 1, ELEMENT_SIZE))
+      {
+         fprintf (stderr, "FAIL: one past the boundary length was accepted\n");
+         failures++;
+      }
+   }
+
+   if (failures)
+   {
+      fprintf (stderr, "%d check(s) failed\n", failures);
+      return 1;
+   }
+
+   printf ("all overflow guard checks passed\n");
+   return 0;
+}


### PR DESCRIPTION
Issue #169 pointed out that the allocations in `new_value()` for array and object values (`json.c`, around what's now lines 154 and 167) can overflow: `value->u.array.length` and `value->u.object.length` are each bounded by `UINT_MAX - 8`, and on a platform where `size_t` is 32 bits wide (same width as `unsigned int` there), multiplying that length by `sizeof(json_value *)` or by the object entry size can wrap around before it ever reaches `json_alloc`. The result is an allocation far smaller than what the second pass then writes into.

As the issue notes, this isn't trivially exploitable today, since the first pass has to allocate one `json_value` per element before the vulnerable second-pass allocation is even reached, so getting near a billion entries usually means running out of memory first on most systems. It's still worth closing given how widely this gets embedded, including on 32-bit or memory-constrained targets where that first-pass cost is much easier to reach.

Added a guard before each multiplication (array values, object values), plus one for the addition a few lines further down that combines the object's entry-array size with its key-name storage size. All three use the same formula, comparing against a `size_t` copy of the length rather than the raw `unsigned int` field directly, since some compilers can otherwise prove the comparison never fires on a 64-bit build and warn about it (caught this locally under `-Wtautological-constant-out-of-range-compare`).

On testing: actually triggering the wraparound needs a 32-bit `size_t` and over a billion parsed elements, which isn't practical to reproduce end-to-end here or in CI (no 32-bit toolchain available, and the input alone would need to be multiple gigabytes). `tests/test_overflow_guard.c` instead checks the same guard formula against a simulated 32-bit width directly, including reproducing the exact wraparound the unguarded multiplication produces, so it's not just tested by inspection. The existing suite in `tests/test.c` still passes unchanged, and I checked all the standards this repo's CI builds against (C99 through C2x, C++98 through C++2b) build clean with the new code.